### PR TITLE
Make sure we are passing the pointer of args to CapMailer

### DIFF
--- a/lib/capistrano/mailer.rb
+++ b/lib/capistrano/mailer.rb
@@ -14,7 +14,7 @@ module Capistrano
   class Configuration
     module CapistranoMailer
       def send_notification_email(cap, config = {}, *args)
-        CapMailer.deliver_notification_email(cap, config, args)
+        CapMailer.deliver_notification_email(cap, config, *args)
       end
     end
 


### PR DESCRIPTION
Originally saw this issue in Capistrano-Mailer-Railsless (https://github.com/3Crowd/Capistrano-Mailer-Railsless), so I apologize if some things below are incorrect.

Make sure we are passing the pointer of args to 'CapMailer.deliver_notification_email'. Otherwise, notifcation_email will see args as a double array so it will ignore any custom parameters.

Details: 
If you try to specify specify extra info in release_data as follows: 

mailer.send_notification_email( self, {}, :release_data => { :git_user => "ggo" } )

:release_data will not get merged with :git_user because the args from mailer is already an array. When args.get_options! (cap_mailer:33) is called, it is working with [[:release_data => { :it_user => "ggo" } ]] which would return {}. The fix is to make sure args is passed as a pointer to notification_email to avoid the double array.
